### PR TITLE
Add column indicating available data for selected codes

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -28,15 +28,18 @@ datatable_usage <- function(data) {
 #' @importFrom DT datatable
 #' @keywords internal
 datatable_codelist <- function(data, data_desc) {
-  datatable(data,
-    colnames = c("Code", "Description"),
+  datatable(
+    data,
+    colnames = c("Code", "Description", "Usage data"),
     rownames = FALSE,
     extensions = c("Buttons", "Scroller"),
     options = list(
       columnDefs = list(
         list(width = "50px", targets = 0),
-        list(width = "500px", targets = 1)
+        list(width = "400px", targets = 1),
+        list(width = "100px", targets = 2)
       ),
+      order = list(list(2, "desc")),
       pageLength = 20,
       scrollX = TRUE,
       searching = FALSE,
@@ -52,5 +55,13 @@ datatable_codelist <- function(data, data_desc) {
       scrollY = 400,
       scroller = TRUE
     )
-  )
+  ) |> 
+    DT::formatStyle(
+      "usage_data_available", 
+      color = DT::styleEqual(
+        c("Available", "Not available"), 
+        c("#35B779FF", "#ED6925FF")
+      ),
+      fontWeight = "bold"
+    )
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -108,7 +108,7 @@ app_ui <- function(request) {
     ),
     layout_columns(
       value_box(
-        title = "Number of selected codes",
+        title = "Number of selected codes with usage data",
         value = textOutput("unique_codes"),
         showcase = bs_icon("file-earmark-medical")
       ),


### PR DESCRIPTION
Closes #27 

Here is a suggestion how to expose this information in a simple way for now. If no codes are selected a message is shown by default:

> No codes have been selected. Please select codes or load a codelist.

This adds only a minimal change to the already existing table, with a new column indicating whether code usage data is availble for each individual code in the selected codelist. 

I also noticed that we should be clearer with the description showing the number of selected codes with usage data in the top, so it now reads: "Number of selected codes **with usage data**". We could consider adding another value box with a count of selected codes (including the codes with no usage data).

For the codelist in the issue (`nhsd-primary-care-domain-refsets/afib_cod/20241205`/) this now looks like this:

<img width="1892" alt="Screenshot 2025-02-27 at 22 34 31" src="https://github.com/user-attachments/assets/4d416ab6-bee2-4108-9139-4aef338dbada" />

