### PR TITLE
Improve `pkgdown` and Shiny App UI

### DIFF
--- a/R/run_app.R
+++ b/R/run_app.R
@@ -1,4 +1,4 @@
-#' Run [Code Usage Explorer](https://milanwiedemann.shinyapps.io/opencodes/) Shiny App
+#' Run `opencodes` [Shiny App](https://milanwiedemann.shinyapps.io/opencodes/) locally
 #'
 #' @export
 run_app <- function() {

--- a/R/ui.R
+++ b/R/ui.R
@@ -13,7 +13,7 @@
 app_ui <- function(request) {
   page_sidebar(
     theme = bs_theme(version = 5, bootswatch = "lumen"),
-    title = "opencodes: Explore clinical code usage in England",
+    title = NULL,
     sidebar = sidebar(
       width = "23%",
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,3 +14,18 @@ reference:
 - title: Shiny App
   contents:
   - run_app
+
+navbar:
+  structure:
+    left:
+    - home
+    - reference
+    - launch_shiny
+    right:
+    - search
+    - github
+
+  components:
+    launch_shiny:
+      text: "Launch Shiny App"
+      href: articles/app.html

--- a/data-raw/icd10_code_usage.R
+++ b/data-raw/icd10_code_usage.R
@@ -143,15 +143,15 @@ icd10_usage <- icd10_usage |>
 sum(is.na(icd10_usage$usage)) == 0
 
 # Check codes with missing description
-icd10_usage |> 
-  filter(is.na(description)) |> 
-  select(icd10_code, description, usage) |> 
-  distinct() |> 
+icd10_usage |>
+  filter(is.na(description)) |>
+  select(icd10_code, description, usage) |>
+  distinct() |>
   print(n = 39)
 # A tibble: 38 × 3
 
 # Remove "codes" with missing description
-icd10_usage <- icd10_usage |> 
+icd10_usage <- icd10_usage |>
   filter(!is.na(description))
 
 # Check encoding problems before fix

--- a/data-raw/opcs4_code_usage.R
+++ b/data-raw/opcs4_code_usage.R
@@ -142,15 +142,15 @@ opcs4_usage <- opcs4_usage |>
 sum(is.na(opcs4_usage$usage)) == 0
 
 # Check codes with missing description
-opcs4_usage |> 
-  filter(is.na(description)) |> 
-  select(opcs4_code, description, usage) |> 
-  distinct() |> 
+opcs4_usage |>
+  filter(is.na(description)) |>
+  select(opcs4_code, description, usage) |>
+  distinct() |>
   print(n = 32)
 # A tibble: 32 × 3
 
 # Remove "codes" with missing description
-opcs4_usage <- opcs4_usage |> 
+opcs4_usage <- opcs4_usage |>
   filter(!is.na(description))
 
 # Check encoding problems before fix

--- a/data-raw/snomed_code_usage.R
+++ b/data-raw/snomed_code_usage.R
@@ -85,9 +85,9 @@ snomed_usage <- snomed_usage |>
 sum(is.na(snomed_usage$usage)) == 0
 
 # Check codes with missing description
-snomed_usage |> 
-  filter(is.na(description)) |> 
-  select(snomed_code, description, usage) |> 
+snomed_usage |>
+  filter(is.na(description)) |>
+  select(snomed_code, description, usage) |>
   distinct()
 # A tibble: 0 × 3
 

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -2,10 +2,10 @@
 % Please edit documentation in R/run_app.R
 \name{run_app}
 \alias{run_app}
-\title{Run \href{https://milanwiedemann.shinyapps.io/opencodes/}{Code Usage Explorer} Shiny App}
+\title{Run \code{opencodes} \href{https://milanwiedemann.shinyapps.io/opencodes/}{Shiny App} locally}
 \usage{
 run_app()
 }
 \description{
-Run \href{https://milanwiedemann.shinyapps.io/opencodes/}{Code Usage Explorer} Shiny App
+Run \code{opencodes} \href{https://milanwiedemann.shinyapps.io/opencodes/}{Shiny App} locally
 }

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -164,4 +164,3 @@ test_that("Test OPCS-4 missing description", {
   test_sum_missing_description <- sum(is.na(opcs4_usage$description))
   expect_equal(test_sum_missing_description, 0)
 })
-

--- a/vignettes/app.Rmd
+++ b/vignettes/app.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "OpenCodes App: Explore clinical code usage in England"
+title: "Shiny App"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{app}


### PR DESCRIPTION
- This removes the "Articles" from the navbar and adds a "Launch Shiny App" tab. Once we actually have some other articles we should add that section again.
- Remove the title bar from the app as we mainly intend users to go to the app through the pkgdown website https://bennettoxford.github.io/opencodes/ and we otherwise always would have two title bars.